### PR TITLE
Adicionando backend de pontos avaliados

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -25,10 +25,14 @@ app.use(cors(corsOptions));
 // Este arquivo define todas as rotas e lógicas para manipular dados de microorganismos (ex.: criar, listar, etc.).
 const microorganismosRoutes = require('./routes/microorganismosRoutes');
 
+const pontosAvaliadosRoutes = require('./routes/pontosAvaliadosRoutes');
+
 // Associa as rotas importadas ao caminho base "/api/microorganismos"
 // Todas as rotas definidas no arquivo microorganismosRoutes serão acessíveis a partir deste caminho base.
 // Exemplo: uma rota GET definida como "/" no arquivo microorganismosRoutes será acessada como "/api/microorganismos".
 app.use('/api/microorganismos', microorganismosRoutes);
+
+app.use('/api/pontosavaliados', pontosAvaliadosRoutes);
 
 app.get('/', (req, res) => {
   res.send("Está funcionando!");

--- a/backend/src/controllers/microorganismosController.js
+++ b/backend/src/controllers/microorganismosController.js
@@ -5,21 +5,23 @@ const prisma = require('../utils/database');
 // Função assíncrona para criar um microorganismo no banco de dados
 const createMicroorganismo = async (req, res) => {
   try {
-    const { nome, descricao, ativo, data_cadastro, data_desativacao } = req.body;
-
-    if (!nome || ativo === undefined || !data_cadastro) {
-      return res.status(400).json({ error: 'Os campos nome, ativo e data_cadastro são obrigatórios.' });
+    const { nome, descricao } = req.body;
+    // Validação de campos obrigatórios
+    if (!nome) {
+      return res.status(400).json({ error: 'O campo nome é obrigatório.' });
     }
 
     // Verifica se o microrganismo já existe
-    const existingMicroorganismo = await prisma.microorganismos.findFirst({ where: { nome } });
+    const existingMicroorganismo = await prisma.microorganismos.findFirst({
+      where: { nome },
+    });
 
     if (existingMicroorganismo) {
       if (!existingMicroorganismo.ativo) {
-        // Atualiza o microrganismo para ativo
+        // Reativa o microrganismo se ele estiver inativo
         const updatedMicroorganismo = await prisma.microorganismos.update({
           where: { id: existingMicroorganismo.id },
-          data: { ativo: true },
+          data: { ativo: true, data_desativacao: null },
         });
         return res.status(200).json(updatedMicroorganismo);
       } else {
@@ -27,13 +29,13 @@ const createMicroorganismo = async (req, res) => {
       }
     }
 
+    // Criação de um novo microrganismo
     const novoMicroorganismo = await prisma.microorganismos.create({
       data: {
         nome,
         descricao,
-        ativo,
-        data_cadastro: new Date(data_cadastro),
-        data_desativacao: data_desativacao ? new Date(data_desativacao) : null,
+        ativo: true, // Define como ativo por padrão
+        data_cadastro: new Date(), // Define a data atual
       },
     });
 
@@ -44,11 +46,15 @@ const createMicroorganismo = async (req, res) => {
   }
 };
 
-// Função assíncrona para buscar todos os microorganismos no banco de dados
+// Função assíncrona para buscar todos os microorganismos ativos no banco de dados
 const getMicroorganismos = async (req, res) => {
   try {
-    // Busca todos os registros da tabela 'microorganismos'
-    const microorganismos = await prisma.microorganismos.findMany();
+    // Busca apenas os microorganismos que estão ativos
+    const microorganismos = await prisma.microorganismos.findMany({
+      where: {
+        ativo: true, // Filtra apenas os registros com ativo = true
+      },
+    });
 
     // Retorna os microorganismos encontrados em formato JSON
     res.status(200).json(microorganismos);
@@ -59,26 +65,44 @@ const getMicroorganismos = async (req, res) => {
   }
 };
 
-// Função assíncrona para editar um microorganismo no banco de dados
+// Função assíncrona para editar um microrganismo no banco de dados
 const updateMicroorganismo = async (req, res) => {
   try {
-    const { id } = req.params;
-    const { nome, descricao, ativo, data_desativacao } = req.body;
+    const { id } = req.params; // Obtém o ID da requisição
+    const { nome, descricao, ativo } = req.body; // Obtém os dados da requisição
 
+    // Busca o microrganismo pelo ID
+    const existingMicroorganismo = await prisma.microorganismos.findUnique({
+      where: { id: parseInt(id) }, // Converte o ID para inteiro
+    });
+
+    // Retorna erro se o microrganismo não for encontrado
+    if (!existingMicroorganismo) {
+      return res.status(404).json({ error: 'Microrganismo não encontrado.' });
+    }
+
+    // Gerencia a data de desativação
+    let data_desativacao = existingMicroorganismo.data_desativacao;
+    if (ativo === false && existingMicroorganismo.ativo === true) {
+      data_desativacao = new Date(); // Define a data atual
+    }
+
+    // Atualiza o microrganismo no banco de dados
     const updatedMicroorganismo = await prisma.microorganismos.update({
       where: { id: parseInt(id) },
       data: {
         nome,
         descricao,
         ativo,
-        data_desativacao: data_desativacao ? new Date(data_desativacao) : null,
+        data_desativacao, // Atualiza ou mantém a data de desativação
       },
     });
 
+    // Retorna o microrganismo atualizado
     res.status(200).json(updatedMicroorganismo);
   } catch (error) {
-    console.error('Erro ao editar microorganismo:', error);
-    res.status(500).json({ error: 'Erro ao editar microorganismo.' });
+    console.error('Erro ao editar microrganismo:', error);
+    res.status(500).json({ error: 'Erro ao editar microrganismo.' });
   }
 };
 

--- a/backend/src/controllers/pontosAvaliadosController.js
+++ b/backend/src/controllers/pontosAvaliadosController.js
@@ -1,0 +1,154 @@
+// Importa o Prisma Client configurado no arquivo database.js
+const prisma = require('../utils/database');
+
+// Função assíncrona para criar um ponto avaliado no banco de dados
+const createPontoAvaliado = async (req, res) => {
+    try {
+      const {
+        sala,
+        area,
+        local_processo,
+        metodo,
+        frequencia,
+        zona_proximidade,
+        zona_higienico,
+        data_desativacao,
+      } = req.body;
+  
+      // Validação básica para campos obrigatórios
+      if (
+        !sala ||
+        !area ||
+        !local_processo ||
+        !metodo ||
+        !frequencia ||
+        !zona_higienico ||
+        !zona_proximidade
+      ) {
+        return res.status(400).json({
+          error:
+            'Os campos sala, area, local_processo, metodo, frequencia, zona_higienico e zona_proximidade são obrigatórios.',
+        });
+      }
+  
+      // Verifica se o ponto avaliado já existe pelo par (sala, área)
+      const existingPonto = await prisma.pontosAvaliados.findFirst({
+        where: { sala, area },
+      });
+  
+      if (existingPonto) {
+        if (!existingPonto.ativo) {
+          // Reativa o ponto avaliado se ele estiver inativo
+          const updatedPonto = await prisma.pontosAvaliados.update({
+            where: { id: existingPonto.id },
+            data: { ativo: true },
+          });
+          return res.status(200).json(updatedPonto);
+        } else {
+          // Retorna erro se o ponto já está cadastrado e ativo
+          return res
+            .status(400)
+            .json({ error: 'Ponto avaliado já está cadastrado.' });
+        }
+      }
+  
+      // Criação de um novo ponto avaliado com valores padrão
+      const novoPonto = await prisma.pontosAvaliados.create({
+        data: {
+          sala,
+          area,
+          local_processo,
+          metodo,
+          frequencia,
+          zona_proximidade,
+          zona_higienico,
+          ativo: true, // Definindo ativo como true por padrão
+          data_cadastro: new Date(), // Gerando automaticamente a data atual
+          data_desativacao: data_desativacao ? new Date(data_desativacao) : null,
+        },
+      });
+  
+      res.status(201).json(novoPonto);
+    } catch (error) {
+      console.error('Erro ao criar ponto avaliado:', error);
+      res.status(500).json({ error: 'Erro ao criar ponto avaliado.' });
+    }
+};
+  
+// Função assíncrona para buscar todos os pontos avaliados com ativo = true
+const getPontosAvaliados = async (req, res) => {
+    try {
+      // Recupera apenas os pontos avaliados que estão ativos
+      const pontos = await prisma.pontosAvaliados.findMany({
+        where: {
+          ativo: true, // Filtra apenas os pontos com ativo = true
+        },
+      });
+  
+      res.status(200).json(pontos);
+    } catch (error) {
+      console.error('Erro ao buscar pontos avaliados:', error);
+      res.status(500).json({ error: 'Erro ao buscar pontos avaliados.' });
+    }
+};
+
+// Função assíncrona para editar um ponto avaliado
+const updatePontoAvaliado = async (req, res) => {
+    try {
+      const { id } = req.params;
+      const {
+        sala,
+        area,
+        local_processo,
+        metodo,
+        frequencia,
+        zona_proximidade,
+        zona_higienico,
+        ativo,
+      } = req.body;
+  
+      // Busca o ponto avaliado pelo ID para validar alterações
+      const existingPonto = await prisma.pontosAvaliados.findUnique({
+        where: { id: parseInt(id) },
+      });
+  
+      if (!existingPonto) {
+        // Retorna erro se o ponto avaliado não for encontrado
+        return res.status(404).json({ error: 'Ponto avaliado não encontrado.' });
+      }
+  
+      // Atualiza data de desativação se o campo ativo mudar de true para false
+      let data_desativacao = existingPonto.data_desativacao;
+      if (ativo === false && existingPonto.ativo === true) {
+        data_desativacao = new Date(); // Define a data atual
+      }
+  
+      // Atualiza o ponto avaliado no banco de dados
+      const updatedPonto = await prisma.pontosAvaliados.update({
+        where: { id: parseInt(id) },
+        data: {
+          sala,
+          area,
+          local_processo,
+          metodo,
+          frequencia,
+          zona_proximidade,
+          zona_higienico,
+          ativo,
+          data_desativacao,
+        },
+      });
+  
+      res.status(200).json(updatedPonto);
+    } catch (error) {
+      console.error('Erro ao editar ponto avaliado:', error);
+      res.status(500).json({ error: 'Erro ao editar ponto avaliado.' });
+    }
+  };
+  
+  // Exporta as funções
+  module.exports = {
+    createPontoAvaliado,
+    getPontosAvaliados,
+    updatePontoAvaliado,
+  };

--- a/backend/src/routes/pontosAvaliadosRoutes.js
+++ b/backend/src/routes/pontosAvaliadosRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+
+const { createPontoAvaliado, getPontosAvaliados, updatePontoAvaliado, getPontoAvaliadoById} = require('../controllers/pontosAvaliadosController');
+
+const router = express.Router();
+
+router.post('/', createPontoAvaliado);
+router.get('/', getPontosAvaliados);
+router.put('/:id', updatePontoAvaliado);
+
+module.exports = router;


### PR DESCRIPTION
Este PR adiciona as funcionalidades relacionadas à entidade Pontos Avaliados, incluindo:

Criação da entidade Pontos Avaliados no backend

Implementação das rotas:

- POST /api/pontos-avaliados → Criar um novo ponto avaliado
- GET /api/pontos-avaliados → Listar todos os pontos avaliados ativos
- PUT /api/pontos-avaliados/:id → Atualizar um ponto avaliado

Validações para evitar duplicação de pontos avaliados

Regras para ativação/desativação de pontos avaliados