### PR TITLE
funções e rotas de limites de contagem e pequeno ajuste em pontos avaliados

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,11 +11,11 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@prisma/client": "^6.2.1",
+    "@prisma/client": "^6.3.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
-    "prisma": "^6.2.1"
+    "prisma": "^6.3.1"
   },
   "devDependencies": {
     "eslint": "^9.18.0",

--- a/backend/prisma/migrations/20250206183018_init/migration.sql
+++ b/backend/prisma/migrations/20250206183018_init/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "LimitesContagem" ADD COLUMN     "ativo" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "data_desativacao" TIMESTAMP(3);

--- a/backend/prisma/migrations/20250206185319_init/migration.sql
+++ b/backend/prisma/migrations/20250206185319_init/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `data_cadastro` to the `LimitesContagem` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "LimitesContagem" ADD COLUMN     "data_cadastro" TIMESTAMP(3) NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -46,6 +46,9 @@ model LimitesContagem {
   pontos_avaliados_id Int
   microorganismos     Microorganismos @relation(fields: [microorganismos_id], references: [id])
   microorganismos_id  Int
+  ativo               Boolean         @default(true)
+  data_cadastro       DateTime
+  data_desativacao    DateTime?
   resultados          Resultados[]
 }
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -27,12 +27,16 @@ const microorganismosRoutes = require('./routes/microorganismosRoutes');
 
 const pontosAvaliadosRoutes = require('./routes/pontosAvaliadosRoutes');
 
+const limitesContagemRoutes = require('./routes/limitesContagemRoutes');
+
 // Associa as rotas importadas ao caminho base "/api/microorganismos"
 // Todas as rotas definidas no arquivo microorganismosRoutes serão acessíveis a partir deste caminho base.
 // Exemplo: uma rota GET definida como "/" no arquivo microorganismosRoutes será acessada como "/api/microorganismos".
 app.use('/api/microorganismos', microorganismosRoutes);
 
 app.use('/api/pontosavaliados', pontosAvaliadosRoutes);
+
+app.use('/api/limitescontagem', limitesContagemRoutes);
 
 app.get('/', (req, res) => {
   res.send("Está funcionando!");

--- a/backend/src/controllers/limitesContagemController.js
+++ b/backend/src/controllers/limitesContagemController.js
@@ -1,0 +1,130 @@
+// Importa o Prisma Client configurado no arquivo database.js
+const prisma = require('../utils/database');
+
+// Função assíncrona para criar um limite de contagem no banco de dados
+const createLimiteContagem = async (req, res) => {
+    try {
+        const { limites_contagem, pontos_avaliados_id, microorganismos_id } = req.body;
+
+        // Validação básica para campos obrigatórios
+        if (!limites_contagem || !pontos_avaliados_id || !microorganismos_id) {
+            return res.status(400).json({
+                error: 'Os campos limites_contagem, pontos_avaliados_id e microorganismos_id são obrigatórios.',
+            });
+        }
+
+        // Valida se o pontos_avaliados_id existe e está ativo
+        const pontoAvaliado = await prisma.pontosAvaliados.findUnique({
+            where: { id: pontos_avaliados_id },
+        });
+
+        if (!pontoAvaliado || !pontoAvaliado.ativo) {
+            return res.status(404).json({ error: 'Ponto avaliado não encontrado ou inativo.' });
+        }
+
+        // Valida se o microorganismos_id existe e está ativo
+        const microorganismo = await prisma.microorganismos.findUnique({
+            where: { id: microorganismos_id },
+        });
+
+        if (!microorganismo || !microorganismo.ativo) {
+            return res.status(404).json({ error: 'Microorganismo não encontrado ou inativo.' });
+        }
+
+        // Verifica se já existe um limite de contagem ativo para o mesmo ponto avaliado e microrganismo
+        const existingLimite = await prisma.limitesContagem.findFirst({
+            where: { pontos_avaliados_id, microorganismos_id, ativo: true },
+        });
+
+        if (existingLimite) {
+            return res.status(400).json({ error: 'Já existe um limite de contagem ativo para este ponto avaliado e microrganismo.' });
+        }
+
+        // Criação do limite de contagem no banco de dados
+        const novoLimiteContagem = await prisma.limitesContagem.create({
+            data: {
+                limites_contagem,
+                pontos_avaliados_id,
+                microorganismos_id,
+                ativo: true, // Sempre cria o limite de contagem como ativo por padrão
+                data_cadastro: new Date(), // Define a data atual
+            },
+        });
+
+        res.status(201).json(novoLimiteContagem);
+    } catch (error) {
+        console.error('Erro ao criar limite de contagem:', error);
+        res.status(500).json({ error: 'Erro ao criar limite de contagem.' });
+    }
+};
+
+// Função assíncrona para buscar todos os limites de contagem ativos
+const getLimiteContagem = async (req, res) => {
+    try {
+        // Recupera apenas os limites de contagem que estão ativos (ativo = true)
+        const limites = await prisma.limitesContagem.findMany({
+            where: {
+                ativo: true, // Filtra apenas os registros ativos
+            },
+            include: {
+                pontos_avaliados: true, // Inclui informações do ponto avaliado relacionado
+                microorganismos: true, // Inclui informações do microorganismo relacionado
+            },
+        });
+
+        // Retorna os limites encontrados em formato JSON
+        res.status(200).json(limites);
+    } catch (error) {
+        // Em caso de erro, exibe o erro no console e retorna um erro 500 (Internal Server Error)
+        console.error('Erro ao buscar limites de contagem:', error);
+        res.status(500).json({ error: 'Erro ao buscar limites de contagem.' });
+    }
+};
+
+// Função assíncrona para atualizar um limite de contagem
+const updateLimiteContagem = async (req, res) => {
+    try {
+        const { id } = req.params; // Obtém o ID do limite de contagem a ser atualizado
+        const { limites_contagem, ativo } = req.body; // Obtém os dados da requisição
+
+        // Busca o limite de contagem pelo ID
+        const existingLimite = await prisma.limitesContagem.findUnique({
+            where: { id: parseInt(id) }, // Converte o ID para inteiro
+        });
+
+        // Retorna erro se o limite de contagem não for encontrado
+        if (!existingLimite) {
+            return res.status(404).json({ error: 'Limite de contagem não encontrado.' });
+        }
+
+        // Se o limite já estiver inativo (ativo = false), não pode ser modificado
+        if (!existingLimite.ativo) {
+            return res.status(400).json({ error: 'Não é possível modificar um limite de contagem inativo.' });
+        }
+
+        // Atualiza a data de desativação se o usuário definir ativo = false
+        let data_desativacao = existingLimite.data_desativacao;
+        if (ativo === false && existingLimite.ativo === true) {
+            data_desativacao = new Date(); // Define a data de desativação como a data atual
+        }
+
+        // Atualiza apenas os campos permitidos
+        const updatedLimite = await prisma.limitesContagem.update({
+            where: { id: parseInt(id) },
+            data: {
+                limites_contagem: limites_contagem || existingLimite.limites_contagem, // Mantém o valor atual se não for enviado
+                ativo: ativo !== undefined ? ativo : existingLimite.ativo, // Mantém o estado atual se não for enviado
+                data_desativacao, // Atualiza apenas se for desativado
+            },
+        });
+
+        // Retorna o limite de contagem atualizado
+        res.status(200).json(updatedLimite);
+    } catch (error) {
+        console.error('Erro ao atualizar limite de contagem:', error);
+        res.status(500).json({ error: 'Erro ao atualizar limite de contagem.' });
+    }
+};
+
+// Exporta a função para ser utilizada nas rotas
+module.exports = { createLimiteContagem, getLimiteContagem, updateLimiteContagem };

--- a/backend/src/controllers/microorganismosController.js
+++ b/backend/src/controllers/microorganismosController.js
@@ -47,7 +47,7 @@ const createMicroorganismo = async (req, res) => {
 };
 
 // Função assíncrona para buscar todos os microorganismos ativos no banco de dados
-const getMicroorganismos = async (req, res) => {
+const getMicroorganismo = async (req, res) => {
   try {
     // Busca apenas os microorganismos que estão ativos
     const microorganismos = await prisma.microorganismos.findMany({
@@ -107,4 +107,4 @@ const updateMicroorganismo = async (req, res) => {
 };
 
 // Exporta a função para ser usada em outros módulos (como nas rotas)
-module.exports = { createMicroorganismo, getMicroorganismos, updateMicroorganismo};
+module.exports = { createMicroorganismo, getMicroorganismo, updateMicroorganismo};

--- a/backend/src/controllers/pontosAvaliadosController.js
+++ b/backend/src/controllers/pontosAvaliadosController.js
@@ -59,9 +59,9 @@ const createPontoAvaliado = async (req, res) => {
           area,
           local_processo,
           metodo,
-          frequencia,
-          zona_proximidade,
-          zona_higienico,
+          frequencia: frequencia.toUpperCase(), // Converte para maiúsculas antes de salvar
+          zona_proximidade: zona_proximidade.toUpperCase(), // Converte para maiúsculas antes de salvar
+          zona_higienico: zona_higienico.toUpperCase(), // Converte para maiúsculas antes de salvar
           ativo: true, // Definindo ativo como true por padrão
           data_cadastro: new Date(), // Gerando automaticamente a data atual
           data_desativacao: data_desativacao ? new Date(data_desativacao) : null,
@@ -76,7 +76,7 @@ const createPontoAvaliado = async (req, res) => {
 };
   
 // Função assíncrona para buscar todos os pontos avaliados com ativo = true
-const getPontosAvaliados = async (req, res) => {
+const getPontoAvaliado = async (req, res) => {
     try {
       // Recupera apenas os pontos avaliados que estão ativos
       const pontos = await prisma.pontosAvaliados.findMany({
@@ -144,11 +144,13 @@ const updatePontoAvaliado = async (req, res) => {
       console.error('Erro ao editar ponto avaliado:', error);
       res.status(500).json({ error: 'Erro ao editar ponto avaliado.' });
     }
-  };
+};
+
+  
   
   // Exporta as funções
   module.exports = {
     createPontoAvaliado,
-    getPontosAvaliados,
+    getPontoAvaliado,
     updatePontoAvaliado,
   };

--- a/backend/src/routes/limitesContagemRoutes.js
+++ b/backend/src/routes/limitesContagemRoutes.js
@@ -1,0 +1,20 @@
+// Importa o módulo `express`, que é o framework usado para criar servidores e rotas HTTP.
+const express = require('express');
+
+// Importa a função `createMicroorganismo` do arquivo de controlador localizado no diretório `controllers`.
+// Essa função é responsável por lidar com a lógica de criação de um microorganismo.
+const { createLimiteContagem, getLimiteContagem, updateLimiteContagem } = require('../controllers/limitesContagemController');
+
+// Cria uma nova instância de um roteador do Express, que será usada para definir as rotas específicas deste recurso.
+const router = express.Router();
+
+// Define uma rota HTTP do tipo POST na raiz (`/`) deste roteador.
+// Quando essa rota é acessada, ela chama a função `createMicroorganismo` para processar a requisição.
+router.post('/', createLimiteContagem);
+router.get('/', getLimiteContagem);
+router.put('/:id', updateLimiteContagem); 
+
+
+
+// Exporta o roteador para que ele possa ser usado em outros arquivos (como no `app.js`).
+module.exports = router;

--- a/backend/src/routes/microorganismosRoutes.js
+++ b/backend/src/routes/microorganismosRoutes.js
@@ -3,7 +3,7 @@ const express = require('express');
 
 // Importa a função `createMicroorganismo` do arquivo de controlador localizado no diretório `controllers`.
 // Essa função é responsável por lidar com a lógica de criação de um microorganismo.
-const { createMicroorganismo, getMicroorganismos, updateMicroorganismo } = require('../controllers/microorganismosController');
+const { createMicroorganismo, getMicroorganismo, updateMicroorganismo } = require('../controllers/microorganismosController');
 
 // Cria uma nova instância de um roteador do Express, que será usada para definir as rotas específicas deste recurso.
 const router = express.Router();
@@ -11,7 +11,7 @@ const router = express.Router();
 // Define uma rota HTTP do tipo POST na raiz (`/`) deste roteador.
 // Quando essa rota é acessada, ela chama a função `createMicroorganismo` para processar a requisição.
 router.post('/', createMicroorganismo);
-router.get('/', getMicroorganismos);
+router.get('/', getMicroorganismo);
 router.put('/:id', updateMicroorganismo); 
 
 

--- a/backend/src/routes/pontosAvaliadosRoutes.js
+++ b/backend/src/routes/pontosAvaliadosRoutes.js
@@ -1,11 +1,11 @@
 const express = require('express');
 
-const { createPontoAvaliado, getPontosAvaliados, updatePontoAvaliado, getPontoAvaliadoById} = require('../controllers/pontosAvaliadosController');
+const { createPontoAvaliado, getPontoAvaliado, updatePontoAvaliado } = require('../controllers/pontosAvaliadosController');
 
 const router = express.Router();
 
 router.post('/', createPontoAvaliado);
-router.get('/', getPontosAvaliados);
+router.get('/', getPontoAvaliado);
 router.put('/:id', updatePontoAvaliado);
 
 module.exports = router;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - postgres
     networks:
       - microdata_network
-    entrypoint: ["/bin/sh", "-c", "npx prisma migrate dev && npm start"]
+    entrypoint: ["/bin/sh", "-c", "npx prisma migrate dev --name init && npm start"]
 
   frontend:
     build:


### PR DESCRIPTION
# funções e rotas de limites de contagem e pequeno ajuste em pontos avaliados

## O que foi feito?
- Ajustada a conversão automática para maiúsculas nos enums (`frequencia`, `zona_proximidade`, `zona_higienico`)
- Correções na criação de **Pontos Avaliados** e **Limites de Contagem**
- Adicionadas validações para garantir que os IDs de pontos avaliados e microrganismos existam antes da criação do limite de contagem
- Ajustada a lógica de atualização, impedindo modificações em limites de contagem inativos
- Melhorias na listagem, garantindo que apenas registros ativos sejam retornados
