### PR TITLE
Adicionando rota e função para o backend do grafico

### DIFF
--- a/backend/src/controllers/limitesContagemController.js
+++ b/backend/src/controllers/limitesContagemController.js
@@ -53,7 +53,7 @@ const createLimiteContagem = async (req, res) => {
                 pontos_avaliados_id,
                 microorganismos_id,
                 ativo: true,
-                data_cadastro: new Date(),
+                data_cadastro: new Date(), //certo, agora eu preciso pensar na logica para fazer um dashboard, no caso eu dashboard de linha sendo contagem x tempo, e eu quero meio que uma linha mostrando os resultados ao longo do tempo, e se puder tambem colocar uma li
             },
         });
 

--- a/backend/src/routes/resultadosRoutes.js
+++ b/backend/src/routes/resultadosRoutes.js
@@ -2,7 +2,7 @@
 const express = require('express');
 
 // Importa a função `createMicroorganismo` do arquivo de controlador localizado no diretório `controllers`.
-const { createResultado, getResultado, updateResultado } = require('../controllers/resultadosController');
+const { createResultado, getResultado, updateResultado, getResultadosGrafico } = require('../controllers/resultadosController');
 
 // Cria uma nova instância de um roteador do Express, que será usada para definir as rotas específicas deste recurso.
 const router = express.Router();
@@ -10,7 +10,8 @@ const router = express.Router();
 // Define uma rota HTTP do tipo POST na raiz (`/`) deste roteador.
 router.post('/', createResultado);
 router.get('/', getResultado);
-router.put('/:id', updateResultado); 
+router.put('/:id', updateResultado);
+router.post('/grafico', getResultadosGrafico); 
 
 
 


### PR DESCRIPTION
# Adição de Endpoint para Consulta de Resultados para Gráfico

## Descrição
Este PR adiciona um novo endpoint para consultar resultados filtrados para a construção de gráficos de contagem ao longo do tempo.

## Principais Alterações
- Implementação da rota `POST /api/resultados/grafico`
- Adição de filtros para busca de resultados, incluindo:
  - `pontos_avaliados_id` (obrigatório)
  - `microorganismos_id` (obrigatório)
  - `zona_higienico` (opcional)
  - `data_inicio` e `data_fim` (ao menos uma é obrigatória)
- Retorno de dados formatados para visualização em gráficos de linha:
  - `data`: Data do resultado coletado
  - `contagem`: Valor do resultado coletado
  - `limite_contagem`: Limite de contagem cadastrado