### PR TITLE
Ajustes para incluir dados relacionados na resposta de edição de limi…

### DIFF
--- a/backend/src/controllers/limitesContagemController.js
+++ b/backend/src/controllers/limitesContagemController.js
@@ -131,6 +131,10 @@ const updateLimiteContagem = async (req, res) => {
                 ativo: ativo !== undefined ? ativo : existingLimite.ativo,
                 data_desativacao,
             },
+            include: {
+                microorganismos: true, // Inclui dados do microorganismo relacionado
+                pontos_avaliados: true, // Inclui dados do ponto avaliado relacionado
+            },
         });
 
         res.status(200).json(updatedLimite);
@@ -139,6 +143,7 @@ const updateLimiteContagem = async (req, res) => {
         res.status(500).json({ error: 'Erro ao atualizar limite de contagem.' });
     }
 };
+
 
 
 // Exporta a função para ser utilizada nas rotas

--- a/frontend/src/components/LimiteContagemForm.jsx
+++ b/frontend/src/components/LimiteContagemForm.jsx
@@ -7,7 +7,7 @@ import { getPontosAvaliados } from '../services/pontosavaliadosAPI';
 import { createLimiteContagem } from '../services/limitecontagemAPI';
 import InputSelect from './InputSelect';
 
-function LimiteContagemForm({ onAdd, onUpdate, isEditing }) {
+function LimiteContagemForm({ onAdd, onUpdate, isEditing, initialData }) {
     const [microorganismo, setMicroorganismo] = useState('');
     const [local, setLocal] = useState('');
     const [dataMicro, setDataMicro] = useState([]);
@@ -31,12 +31,12 @@ function LimiteContagemForm({ onAdd, onUpdate, isEditing }) {
     }, []);
   
     useEffect(() => {
-      console.log("Updated microorganism:", microorganismo);
-    }, [microorganismo]);
-  
-    useEffect(() => {
-      console.log("Updated local:", local);
-    }, [local]);
+      if (initialData && isEditing) {
+          setMicroorganismo(initialData.microorganismos_id);
+          setLocal(initialData.pontos_avaliados_id);
+          setLimiteContagem(initialData.limites_contagem);
+      }
+    }, [initialData, isEditing]);
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -45,11 +45,13 @@ function LimiteContagemForm({ onAdd, onUpdate, isEditing }) {
           return;
         }
     
-        const data = {
-          limites_contagem: limiteContagem,
-          pontos_avaliados_id: local,
-          microorganismos_id: microorganismo,
-        };
+        const data = isEditing
+            ? { limites_contagem: limiteContagem } // Apenas o campo editável
+            : {
+                limites_contagem: limiteContagem,
+                pontos_avaliados_id: local,
+                microorganismos_id: microorganismo,
+            };
     
         if(isEditing) {
           onUpdate(data);
@@ -77,21 +79,26 @@ function LimiteContagemForm({ onAdd, onUpdate, isEditing }) {
                     borderRadius: '1rem'
                 }}
             >
-                <InputSelect
-                    label="Microorganismo"
-                    value={microorganismo}
-                    onChange={(event) => setMicroorganismo(event.target.value)}
-                    items={dataMicro}
-                    displayField={'nome'}
-                />
+                {/* Campos de seleção visíveis apenas no modo de adição */}
+                {!isEditing && (
+                    <>
+                        <InputSelect
+                            label="Microorganismo"
+                            value={microorganismo}
+                            onChange={(event) => setMicroorganismo(event.target.value)}
+                            items={dataMicro}
+                            displayField={'nome'}
+                        />
 
-                <InputSelect
-                    label="Local da Coleta"
-                    value={local}
-                    onChange={(event) => setLocal(event.target.value)}
-                    items={dataLocal}
-                    displayField={'local_processo'}
-                />
+                        <InputSelect
+                            label="Local da Coleta"
+                            value={local}
+                            onChange={(event) => setLocal(event.target.value)}
+                            items={dataLocal}
+                            displayField={'local_processo'}
+                        />
+                    </>
+                )}
 
                 {/* Campo de texto para limite de contagem */}
                 <TextField
@@ -111,18 +118,45 @@ function LimiteContagemForm({ onAdd, onUpdate, isEditing }) {
                         width: '100%'
                     }}
                 >
-                    <CustomButton 
-                        text="Limpar"  
-                        type="button"  
-                        color="#B83226" 
-                        variant="outlined" 
-                        onClick={() => {
-                            setMicroorganismo('');
-                            setLocal('');
-                            setLimiteContagem('');
-                          }} 
-                     />
-                    <CustomButton text="Cadastrar" type="submit" color="#B83226" variant="contained" />
+                    {isEditing ? (
+                        <>
+                            <CustomButton
+                                text="Cancelar"
+                                type="button"
+                                color="#B83226"
+                                variant="outlined"
+                                onClick={() => {
+                                    onUpdate(null); // Cancela edição
+                                }}
+                            />
+                            <CustomButton
+                                text="Atualizar"
+                                type="submit"
+                                color="#B83226"
+                                variant="contained"
+                            />
+                        </>
+                    ) : (
+                        <>
+                            <CustomButton
+                                text="Limpar"
+                                type="button"
+                                color="#B83226"
+                                variant="outlined"
+                                onClick={() => {
+                                    setMicroorganismo('');
+                                    setLocal('');
+                                    setLimiteContagem('');
+                                }}
+                            />
+                            <CustomButton
+                                text="Cadastrar"
+                                type="submit"
+                                color="#B83226"
+                                variant="contained"
+                            />
+                        </>
+                    )}
                 </Box>
             </Box>
         </div>

--- a/frontend/src/components/LimiteContagemTable.jsx
+++ b/frontend/src/components/LimiteContagemTable.jsx
@@ -29,7 +29,7 @@ const LimiteContagemTable = ({ data, onEdit, onDelete }) => {
                 {item.microorganismos?.nome || "N/A"}
               </TableCell>
               <TableCell sx={{ textAlign: 'center' }}>
-                {item.pontos_avaliados?.nome || "N/A"}
+                {item.pontos_avaliados?.sala || "N/A"}
               </TableCell>
               <TableCell sx={{ textAlign: 'center' }}>
                 {item.limites_contagem}

--- a/frontend/src/pages/LimiteContagem.jsx
+++ b/frontend/src/pages/LimiteContagem.jsx
@@ -54,7 +54,7 @@ function LimiteContagem() {
       setSelectedLimite(null);
     } catch (error) {
       console.error('Erro ao atualizar limite de contagem:', error);
-    }
+    } 
   };
 
   // Instead of deleting immediately, set the item to be deleted.


### PR DESCRIPTION
- Implementação da funcionalidade de edição para limites de contagem.
- Ajuste na resposta do backend para incluir os dados relacionados (`microorganismos` e `pontos_avaliados`) ao editar um limite de contagem.
- Garantido que os dados da tabela sejam atualizados corretamente após a edição, sem necessidade de recarregar a página.
